### PR TITLE
78 - Fix checksum migration issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql
+++ b/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql
@@ -1,10 +1,10 @@
 -- filter contact docs into one place
-CREATE OR REPLACE VIEW raw_contacts AS SELECT * FROM couchdb WHERE doc->>'type' IN ('clinic', 'district_hospital', 'health_center', 'person', 'contact');
+CREATE OR REPLACE VIEW raw_contacts AS SELECT * FROM couchdb WHERE doc->>'type' IN ('clinic', 'district_hospital', 'health_center', 'person');
 
 -- extract JSON data from contact docs and cache it
 DROP MATERIALIZED VIEW IF EXISTS contactview_metadata CASCADE;
 CREATE MATERIALIZED VIEW contactview_metadata AS
-SELECT doc->>'_id' AS uuid, doc->>'name' AS name, doc->>'type' AS type, doc->>'contact_type' AS contact_type, doc#>>'{contact,_id}' AS contact_uuid, doc#>>'{parent,_id}' AS parent_uuid, doc->>'notes' AS notes,
+SELECT doc->>'_id' AS uuid, doc->>'name' AS name, doc->>'type' AS type, doc#>>'{contact,_id}' AS contact_uuid, doc#>>'{parent,_id}' AS parent_uuid, doc->>'notes' AS notes,
 TIMESTAMP WITH TIME ZONE 'epoch' + (doc->>'reported_date')::numeric / 1000 * interval '1 second' AS reported
 FROM raw_contacts;
 

--- a/libs/analytics/migrations/202104281912.do.0078-contactType.sql
+++ b/libs/analytics/migrations/202104281912.do.0078-contactType.sql
@@ -1,0 +1,56 @@
+-- Recreates the view only to add the new column contact_type
+DROP MATERIALIZED VIEW IF EXISTS contactview_metadata CASCADE;
+CREATE MATERIALIZED VIEW contactview_metadata AS
+  SELECT doc->>'_id' AS uuid,
+    doc->>'name' AS name,
+    doc->>'type' AS type,
+    doc->>'contact_type' AS contact_type,       --> only this is new
+    doc#>>'{contact,_id}' AS contact_uuid,
+    doc#>>'{parent,_id}' AS parent_uuid,
+    doc->>'notes' AS notes,
+    TIMESTAMP WITH TIME ZONE 'epoch' + (doc->>'reported_date')::numeric / 1000 * interval '1 second' AS reported
+  FROM raw_contacts;
+
+CREATE UNIQUE INDEX contactview_metadata_uuid ON contactview_metadata (uuid);
+CREATE INDEX contactview_metadata_contact_uuid ON contactview_metadata (contact_uuid);
+CREATE INDEX contactview_metadata_parent_uuid ON contactview_metadata (parent_uuid);
+CREATE INDEX contactview_metadata_type ON contactview_metadata (type);
+
+-- NOTE: The recreation of the view above caused 4 other views to be dropped in cascade,
+--       here are the scripts to recreate them:
+
+CREATE VIEW contactview_hospital AS
+  SELECT cmd.uuid, cmd.name
+    FROM contactview_metadata AS cmd
+    WHERE cmd.type = 'district_hospital';
+
+CREATE VIEW contactview_chw AS
+  SELECT chw.name, pplfields.*, chwarea.uuid AS area_uuid,
+         chwarea.parent_uuid AS branch_uuid
+    FROM contactview_person_fields AS pplfields
+         INNER JOIN contactview_metadata AS chw ON (chw.uuid = pplfields.uuid)
+         INNER JOIN contactview_metadata AS chwarea ON (chw.parent_uuid = chwarea.uuid)
+    WHERE pplfields.parent_type = 'health_center';
+
+CREATE VIEW contactview_clinic AS
+  SELECT cmd.uuid, cmd.name, chw.uuid AS chw_uuid, cmd.reported AS created
+    FROM contactview_metadata AS cmd
+         INNER JOIN contactview_chw AS chw ON (cmd.parent_uuid = chw.area_uuid)
+    WHERE type = 'clinic';
+
+CREATE VIEW contactview_clinic_person AS
+  SELECT
+      raw_contacts.doc ->> '_id' AS uuid,
+      raw_contacts.doc ->> 'name' AS name,
+      raw_contacts.doc ->> 'type' AS type,
+      raw_contacts.doc #>> '{parent,_id}' AS family_uuid,
+      raw_contacts.doc ->> 'phone' AS phone,
+      raw_contacts.doc ->> 'alternative_phone' AS phone2,
+      raw_contacts.doc ->> 'date_of_birth' AS date_of_birth,
+      cmeta.type AS parent_type
+    FROM
+      raw_contacts
+      LEFT JOIN contactview_metadata AS cmeta ON (doc #>> '{parent,_id}' = cmeta.uuid)
+    WHERE
+      raw_contacts.doc->>'type' = 'person' AND
+      raw_contacts.doc->>'_id' IN (SELECT contact_uuid FROM contactview_metadata WHERE type = 'clinic');

--- a/libs/analytics/migrations/202104281912.do.0078-contactType.sql
+++ b/libs/analytics/migrations/202104281912.do.0078-contactType.sql
@@ -1,4 +1,5 @@
 -- Recreates the view only to add the new column contact_type
+-- Replaces -> https://github.com/medic/medic-couch2pg/blob/53c8b27aa6e33c8e2a62dc7d8f697cad20b891c7/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql#L5-L25
 DROP MATERIALIZED VIEW IF EXISTS contactview_metadata CASCADE;
 CREATE MATERIALIZED VIEW contactview_metadata AS
   SELECT doc->>'_id' AS uuid,
@@ -19,11 +20,13 @@ CREATE INDEX contactview_metadata_type ON contactview_metadata (type);
 -- NOTE: The recreation of the view above caused 4 other views to be dropped in cascade,
 --       here are the scripts to recreate them:
 
+-- Replace -> https://github.com/medic/medic-couch2pg/blob/53c8b27aa6e33c8e2a62dc7d8f697cad20b891c7/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql#L31
 CREATE VIEW contactview_hospital AS
   SELECT cmd.uuid, cmd.name
     FROM contactview_metadata AS cmd
     WHERE cmd.type = 'district_hospital';
 
+-- Replace -> https://github.com/medic/medic-couch2pg/blob/53c8b27aa6e33c8e2a62dc7d8f697cad20b891c7/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql#L48
 CREATE VIEW contactview_chw AS
   SELECT chw.name, pplfields.*, chwarea.uuid AS area_uuid,
          chwarea.parent_uuid AS branch_uuid
@@ -32,12 +35,14 @@ CREATE VIEW contactview_chw AS
          INNER JOIN contactview_metadata AS chwarea ON (chw.parent_uuid = chwarea.uuid)
     WHERE pplfields.parent_type = 'health_center';
 
+-- Replace -> https://github.com/medic/medic-couch2pg/blob/53c8b27aa6e33c8e2a62dc7d8f697cad20b891c7/libs/analytics/migrations/201606200952.do.2318-prepareContacts.sql#L57
 CREATE VIEW contactview_clinic AS
   SELECT cmd.uuid, cmd.name, chw.uuid AS chw_uuid, cmd.reported AS created
     FROM contactview_metadata AS cmd
          INNER JOIN contactview_chw AS chw ON (cmd.parent_uuid = chw.area_uuid)
     WHERE type = 'clinic';
 
+-- Replace -> https://github.com/medic/medic-couch2pg/blob/53c8b27aa6e33c8e2a62dc7d8f697cad20b891c7/libs/analytics/migrations/201711071603.do.2635-removeNestedContactReferences.sql#L4
 CREATE VIEW contactview_clinic_person AS
   SELECT
       raw_contacts.doc ->> '_id' AS uuid,


### PR DESCRIPTION
Issue: #78

Rollback changes in immutable migration file and applied intended changes in new SQL script:
    
 - Migrations files are signed with a md5 sum in the DB to avoid modifications. The SQL file was restored to its original state.
- The changes were moved to a new a script, but because is not possible to add a new column to a materialized view, the change was applied recreating the view.
- The changes to the view `raw_contacts` that was rolled back was redundant, because the same migration to add 'contact' to the list of values for `doc->>'type'` was added in an earlier migration script.
- Add a section _"Known issues"_ with a workaround in case somebody did started a fresh database with v3.2.0 and wants to avoid the same migration issue once it tries to upgrade to an upcoming version. Also add another workaround for a unresolved issue with a library when is installed.